### PR TITLE
feat: Add CLI tool and installation instructions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,8 @@
+import asyncio
+from onefilellm import main
+
+def entry_point():
+    asyncio.run(main())
+
+if __name__ == "__main__":
+    entry_point() 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "onefilellm"
+version = "0.1.0"
+description = "A one-file LLM"
+readme = "readme.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "requests==2.28.0",
+    "beautifulsoup4==4.11.1",
+    "PyPDF2==2.10.0",
+    "tiktoken",
+    "nltk==3.7",
+    "nbformat==5.4.0",
+    "nbconvert==6.5.0",
+    "youtube-transcript-api==0.4.1",
+    "pyperclip==1.8.2",
+    "wget==3.2",
+    "tqdm==4.64.0",
+    "rich==12.4.4",
+    "pandas",
+    "openpyxl",
+    "xlrd",
+    "tabulate",
+    "PyYAML",
+    "python-dotenv",
+    "aiohttp",
+    "readability-lxml",
+    "lxml",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/jimmc414/onefilellm"
+"Bug Tracker" = "https://github.com/jimmc414/onefilellm/issues"
+
+[project.scripts]
+onefilellm = "cli:entry_point"
+
+[tool.setuptools]
+py-modules = ["onefilellm", "cli", "utils"] 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,34 @@ python onefilellm.py --alias-add vercel-ai-sdk https://github.com/vercel/ai http
 python onefilellm.py --alias-add mcp-spec https://modelcontextprotocol.io/llms-full.txt https://github.com/modelcontextprotocol/python-sdk
 ```
 
+## Command-Line Interface (CLI)
+
+This project can also be installed as a command-line tool, which allows you to run `onefilellm` directly from your terminal.
+
+### CLI Installation
+
+To install the CLI, run the following command in the project's root directory:
+
+```bash
+pip install -e .
+```
+
+This will install the package in "editable" mode, meaning any changes you make to the source code will be immediately available to the command-line tool.
+
+### CLI Usage
+
+Once installed, you can use the `onefilellm` command instead of `python onefilellm.py`.
+
+**Synopsis:**
+`onefilellm [OPTIONS] [INPUT_SOURCES...]`
+
+**Example:**
+```bash
+onefilellm ./docs/ https://github.com/user/project/issues/123
+```
+
+All other command-line arguments and options work the same as the script-based approach.
+
 **Using an Alias:**
 You can then invoke an alias by its name.
 ```bash


### PR DESCRIPTION
### Description

This pull request enhances the project by making it an installable command-line tool. This improves usability by allowing users to run `onefilellm` directly from the terminal from any directory, rather than having to execute `python onefilellm.py` from the project's root.

This approach maintains full backward compatibility for users who prefer to run the script directly.

#### Key Changes:

*   **`pyproject.toml`**: Adds a standard `pyproject.toml` file to define the package, its dependencies, and configure the command-line entry point. This makes the project compliant with modern Python packaging standards (PEP 621).
*   **`cli.py`**: A new, minimal script that serves as the entry point for the `onefilellm` command. It simply imports and runs the `main` function from the existing `onefilellm.py` script, ensuring the core logic remains untouched.
*   **`readme.md`**: The README has been updated with a new "Command-Line Interface (CLI)" section that provides clear instructions on how to install the package in editable mode and how to use the new `onefilellm` command.

#### How to Test:

1.  From the project root, install the package in editable mode:
    ```bash
    pip install -e .
    ```
2.  Verify that the command is available:
    ```bash
    onefilellm --help
    ```
3.  Run a command with a sample URL:
    ```bash
    onefilellm https://github.com/jimmc414/onefilellm
    ```